### PR TITLE
SSTReceptor based demo for ReceptorIsolate

### DIFF
--- a/ReceptorIsolate/SSTReceptorIsolateDemo.m
+++ b/ReceptorIsolate/SSTReceptorIsolateDemo.m
@@ -49,12 +49,13 @@ receptors = SSTReceptorHuman('verbosity','high',...
     'doPenumbralConesTrueFalse',doPenumbralCones);
 
 %% Plot receptor fundamentals
-plot_quantalIsomerizations = receptors.plotSpectralSensitivities('whichFormat','T_quantalIsomerizations','saveFig',false);
-plot_quantalAbsorptions = receptors.plotSpectralSensitivities('whichFormat','T_quantalAbsorptions','saveFig',false);
-plot_quantalAbsorptionsNormalized = receptors.plotSpectralSensitivities('whichFormat','T_quantalAbsorptionsNormalized','saveFig',false);
-plot_energy = receptors.plotSpectralSensitivities('whichFormat','T_energy','saveFig',false);
-plot_energyNormalized = receptors.plotSpectralSensitivities('whichFormat','T_energyNormalized','saveFig',false);
-% TODO: combine into one plot (using subplots)
+f1 = figure(); clf;
+subplot(2,3,1); plot_quantalIsomerizations = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_quantalIsomerizations','saveFig',false);
+subplot(2,3,2); plot_quantalAbsorptions = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_quantalAbsorptions','saveFig',false);
+subplot(2,3,3); plot_quantalAbsorptionsNormalized = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_quantalAbsorptionsNormalized','saveFig',false);
+subplot(2,2,3); plot_energy = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_energy','saveFig',false);
+subplot(2,2,4); plot_energyNormalized = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_energyNormalized','saveFig',false);
+
 
 %% Define devices
 % devices are defined as structs, with the following fields:

--- a/ReceptorIsolate/SSTReceptorIsolateDemo.m
+++ b/ReceptorIsolate/SSTReceptorIsolateDemo.m
@@ -25,7 +25,7 @@ availableModels = {'Human cones, penumbral cones, rods, and melanopsin',...
     };
 
 % Print each entry
-fprintf('Available receptor models:\n');
+fprintf('<strong>Available receptor models:</strong>\n');
 for i = 1:numel(availableModels)
     fprintf('\t[%i] %s\n',i,availableModels{i})
 end
@@ -123,17 +123,17 @@ devices(3).ambientSpd = SplineSpd(devices(3).cal.S_ambient,devices(3).cal.P_ambi
 devices(3).primaryHeadRoom = 0.02;
 devices(3).maxPowerDiff = 10000;
 
-% Five LED primaries TODO
+% Five LED primaries
 % No smoothness constraint implement, as the smoothness of a monitor
 % spectrum is pretty much determined by the shape of the primaries.
-%devices(4).name = 'FiveLED';
-%devices(4).description = 'Hypothetical device with five LED primaries';
-%devices(4).cal = struct(); % hypothetical devices don't have a calibration file
-%devices(4).S = [380 2 201];
-%devices(4).B_primary = 
-%devices(4).ambientSpd = zeros(devices(4).S(3),1);
-%devices(4).primaryHeadRoom = 0;
-%devices(4).maxPowerDiff = 10000;
+devices(4).name = 'FiveLED';
+devices(4).description = 'Hypothetical device with five LED primaries';
+devices(4).cal = struct(); % hypothetical devices don't have a calibration file
+devices(4).S = [380 2 201];
+devices(4).B_primary = LEDPrimaries(devices(4).S,[456 488 540 592 632],[10 10 10 17 17]/2,[.57 .125 .156 .27 .75]);
+devices(4).ambientSpd = zeros(devices(4).S(3),1);
+devices(4).primaryHeadRoom = 0;
+devices(4).maxPowerDiff = 10000;
 
 %% Select device
 % Print each entry

--- a/ReceptorIsolate/SSTReceptorIsolateDemo.m
+++ b/ReceptorIsolate/SSTReceptorIsolateDemo.m
@@ -1,0 +1,202 @@
+% SSTReceptor Receptor Isolate Demo
+%
+% Demonstration of the ReceptorIsolate engine for finding modulations that
+% isolate various receptors; the receptor fundamentals in this
+% demonstration are generated using the SSTReceptor class(es).
+%
+% NOTE: the SSTReceptorHuman class does not (currently - 10/30/17) correct
+% for photopigment bleaching, unlike the legacy GetHumanPhotoreceptorSS
+% code that the legacy ReceptorIsolateDemo used.
+%
+% NOTE: the SSTReceptorHuman class (currently - 10/30/17) uses fixed
+% standard parameters for vessel oxygenation fraction (.85), and vessel
+% overall thickness (5um).
+
+%% Setup
+% Clear workspace and command window, close plots
+clearvars; close all; clc;
+CheckSSTInstalled();
+
+%% Get receptor fundamentals using SSTReceptor object
+% Select receptor model Description of models can be added to this cell
+% array; all will be presented as options.
+availableModels = {'Human cones, penumbral cones, rods, and melanopsin',...
+    %                   'Dog photoreceptors' TODO
+    };
+
+% Print each entry
+fprintf('Available receptor models:\n');
+for i = 1:numel(availableModels)
+    fprintf('\t[%i] %s\n',i,availableModels{i})
+end
+
+% Prompt, and check input
+receptorModel = GetWithDefault('Enter model number',1);
+assert(receptorModel > 0 && receptorModel <= numel(availableModels),'SST:InputError','Unknown receptor model entered');
+
+% Prompt for values for relevant parameters
+age = GetWithDefault('Observer age (years)?', 32);
+fieldSize = GetWithDefault('Field size (degrees)?', 27.5);
+pupilDiameter = GetWithDefault('Pupil diameter (mm)?', 4.7);
+%vesselOxyFraction = GetWithDefault('Oxygenation fraction for vessel hemoglobin?', 0.85);
+%vesselOverallThicknessUm = GetWithDefault('Vessel thickness?', 5);
+doPenumbralCones = logical(GetWithDefault('Include penumbral cones [1 = yes, 0 = no]?',1));
+
+% Get receptor fundamentals using SSTReceptorHuman object
+receptors = SSTReceptorHuman('verbosity','high',...
+    'obsAgeInYrs',age,...
+    'obsPupilDiameter',pupilDiameter,...
+    'fieldSizeDeg',fieldSize,...
+    'doPenumbralConesTrueFalse',doPenumbralCones);
+
+%% Plot receptor fundamentals
+plot_quantalIsomerizations = receptors.plotSpectralSensitivities('whichFormat','T_quantalIsomerizations','saveFig',false);
+plot_quantalAbsorptions = receptors.plotSpectralSensitivities('whichFormat','T_quantalAbsorptions','saveFig',false);
+plot_quantalAbsorptionsNormalized = receptors.plotSpectralSensitivities('whichFormat','T_quantalAbsorptionsNormalized','saveFig',false);
+plot_energy = receptors.plotSpectralSensitivities('whichFormat','T_energy','saveFig',false);
+plot_energyNormalized = receptors.plotSpectralSensitivities('whichFormat','T_energyNormalized','saveFig',false);
+% TODO: combine into one plot (using subplots)
+
+%% Define devices
+% devices are defined as structs, with the following fields:
+%   .name = shorthand name for device
+%
+%   .description = more detailed (human-readable) description of the device
+%   for the users convenience
+%
+%   .cal = calibration struct for actual devices (e.g., OneLight, monitors)
+%   , empty structs for hypothetical devices.
+%
+%   .S = wavelength sampling, in standard PTB format ( [start delta end] )
+%
+%   .B_primary = device primary basis vectors, in [0-1] range.
+%
+%   .ambientSpd = spectral power distribution of ambient light
+%
+%   .primaryHeadRoom = a constraint that we don't go right to the edge of
+%   the gamut.  The head room parameter is defined in the [0-1] device
+%   primary space.  Using a little head room keeps us a bit away from the
+%   hard edge of the device.
+%
+%   .maxPowerDiff = a smoothness constraint.
+
+% OneLight
+% OneLight device in Brainard/Aguirre lab, with the corresponding
+% calibration data. A small headroom is implemented. Smoothness constraint
+% value is a magic constant defined by hand, that determins the maximum
+% absolute value of the change in spectral power between two adjacent
+% wavelength samples. Thus it's appropriate value depends on the overall
+% power of the viewed light as well as on the wavelength sampling step.
+devices(1).name = 'OneLight';
+devices(1).description = 'Brainard/Aguirre lab OneLight device, and corresponding calibration data';
+devices(1).cal = LoadCalFile('OneLightDemoCal.mat',[],fullfile(fileparts(mfilename('fullpath')),'ReceptorIsolateDemoData'));
+devices(1).S = devices(1).cal.describe.S;
+devices(1).B_primary = devices(1).cal.computed.pr650M;
+devices(1).ambientSpd = devices(1).cal.computed.pr650MeanDark;
+devices(1).primaryHeadRoom = .02;
+devices(1).maxPowerDiff = 10^-1.5;
+
+% Ideal spectrum producing device
+% Hypothetical ideal spectrum producing device, with delta functions of
+% unit power at each wavelength. No headroom or smoothness constraint
+% implemented (as the device is ideal).
+devices(2).name = 'Spectral';
+devices(2).description = 'Hypothetical ideal spectrum producing device (delta function primaries at each wavelength with unit power)';
+devices(2).cal = struct(); % hypothetical devices don't have a calibration file
+devices(2).S = [400 4 76];
+devices(2).B_primary = eye(devices(2).S(3));
+devices(2).ambientSpd = zeros(size(devices(2).B_primary,2),1);
+devices(2).primaryHeadRoom = 0;
+devices(2).maxPowerDiff = 10000;
+
+% Some typical monitor 
+% Typical monitor with calibration data (including ambientSpd) supplied by
+% the PTB. Headroom implemented. No smoothness constraint implemented, as
+% the smoothness of a monitor spectrum is pretty much determined by the
+% shape of the primaries.
+devices(3).name = 'Monitor';
+devices(3).description = 'Some typical monitor (supplied by PTB)';
+devices(3).cal = LoadCalFile('PTB3TestCal');
+devices(3).S = [400 4 76];
+devices(3).B_primary = SplineSpd(devices(3).cal.S_device,devices(3).cal.P_device,devices(3).S);
+devices(3).ambientSpd = SplineSpd(devices(3).cal.S_ambient,devices(3).cal.P_ambient,devices(3).S);
+devices(3).primaryHeadRoom = 0.02;
+devices(3).maxPowerDiff = 10000;
+
+% Five LED primaries TODO
+% No smoothness constraint implement, as the smoothness of a monitor
+% spectrum is pretty much determined by the shape of the primaries.
+%devices(4).name = 'FiveLED';
+%devices(4).description = 'Hypothetical device with five LED primaries';
+%devices(4).cal = struct(); % hypothetical devices don't have a calibration file
+%devices(4).S = [380 2 201];
+%devices(4).B_primary = 
+%devices(4).ambientSpd = zeros(devices(4).S(3),1);
+%devices(4).primaryHeadRoom = 0;
+%devices(4).maxPowerDiff = 10000;
+
+%% Select device
+% Print each entry
+fprintf('Available device primaries:\n');
+for i = 1:numel(devices)
+    fprintf('\t[%i] %s (%s)\n',i,devices(i).name,devices(i).description)
+end
+
+% Prompt, and check input
+input = GetWithDefault('Enter device number',1);
+assert(input > 0 && input <= numel(devices),...
+    'SST:InputError','Unknown device entered: %i. Range [1-%i] expected',input,numel(devices));
+device = devices(input);
+fprintf('Device [%i] selected: %s (%s)\n',input,device.name,device.description);
+
+%% Set background spectrum
+% Half-on in whatever primary space we are working in
+backgroundPrimary = repmat(.5,size(device.B_primary,2),1);
+
+%% Correct for bleaching FIXME
+% correctBleaching = logical( GetWithDefault('Correct for photopigment bleaching [1 = yes, 0 = no]?',1) );
+
+%% Prompt for direction of modulation
+receptorSelection = [receptors.labels',cell(size(receptors.labels'))];
+fprintf('Target [1], Silence [2], or Ignore [3] receptor:\n')
+for i = 1:size(receptorSelection,1)
+    receptorSelection{i,2} = GetWithDefault(sprintf('\t %s',receptorSelection{i,1}),3);
+    assert(receptorSelection{i,2} > 0 && receptorSelection{i,2} <= 3,...
+        'SST:InputError','Receptors should either be targeted [1], silenced [2], or Ignored [3]');
+end
+targetReceptors = find([receptorSelection{:,2}] == 1);
+silenceReceptors = find([receptorSelection{:,2}] == 2);
+ignoredReceptors = find([receptorSelection{:,2}] == 3);
+
+%% Maximize contrast vs. desired contrast TODO
+desiredContrast = [];
+
+%% Create direction spectrum (by calling ReceptorIsolate)
+directionPrimary = ReceptorIsolate(receptors.T.T_energyNormalized,targetReceptors,ignoredReceptors,[],...
+    device.B_primary, backgroundPrimary, backgroundPrimary, [],...
+    device.primaryHeadRoom, device.maxPowerDiff, desiredContrast, device.ambientSpd);
+
+%% Calculate nominal contrasts TODO
+
+%% Generate some plots
+% Plot modulation spectra
+plt_modulationSpectra = figure; hold on;
+plot(SToWls(device.S),device.B_primary*directionPrimary,'r','LineWidth',2);
+plot(SToWls(device.S),device.B_primary*backgroundPrimary,'k','LineWidth',2);
+title('Modulation spectra');
+legend({'Direction','Background'});
+xlim([380 780]);
+xlabel('Wavelength');
+ylabel('Power');
+pbaspect([1 1 1]);
+
+% Plot primaries
+plt_modulationPrimaries = figure; hold on;
+stem(directionPrimary,'r','LineWidth',2);
+stem(backgroundPrimary,'k','LineWidth',2);
+title('Modulation primaries settings');
+legend({'Direction','Background'});
+xlim([1 length(backgroundPrimary)]);
+ylim([0 1]);
+xlabel('Primary number (nominal)');
+ylabel('Setting');

--- a/ReceptorIsolate/SSTReceptorIsolateDemo.m
+++ b/ReceptorIsolate/SSTReceptorIsolateDemo.m
@@ -21,7 +21,6 @@ CheckSSTInstalled();
 % Select receptor model Description of models can be added to this cell
 % array; all will be presented as options.
 availableModels = {'Human cones, penumbral cones, rods, and melanopsin',...
-    %                   'Dog photoreceptors' TODO
     };
 
 % Print each entry
@@ -137,9 +136,9 @@ devices(4).maxPowerDiff = 10000;
 
 %% Select device
 % Print each entry
-fprintf('Available device primaries:\n');
+fprintf('\n<strong>Available devices:</strong>\n');
 for i = 1:numel(devices)
-    fprintf('\t[%i] %s (%s)\n',i,devices(i).name,devices(i).description)
+    fprintf('<strong>\t[%i] %s</strong>: %s\n',i,devices(i).name,devices(i).description)
 end
 
 % Prompt, and check input
@@ -147,7 +146,7 @@ input = GetWithDefault('Enter device number',1);
 assert(input > 0 && input <= numel(devices),...
     'SST:InputError','Unknown device entered: %i. Range [1-%i] expected',input,numel(devices));
 device = devices(input);
-fprintf('Device [%i] selected: %s (%s)\n',input,device.name,device.description);
+fprintf('<strong>Device [%i] selected:</strong> %s (%s)\n',input,device.name,device.description);
 
 %% Set background spectrum
 % Half-on in whatever primary space we are working in
@@ -158,15 +157,21 @@ backgroundPrimary = repmat(.5,size(device.B_primary,2),1);
 
 %% Prompt for direction of modulation
 receptorSelection = [receptors.labels',cell(size(receptors.labels'))];
-fprintf('Target [1], Silence [2], or Ignore [3] receptor:\n')
+fprintf('\n<strong>Target [1], Silence [2], or Ignore [3] receptor:</strong>\n')
 for i = 1:size(receptorSelection,1)
-    receptorSelection{i,2} = GetWithDefault(sprintf('\t %s',receptorSelection{i,1}),3);
+    receptorSelection{i,2} = GetWithDefault(sprintf('\t%s',receptorSelection{i,1}),3);
     assert(receptorSelection{i,2} > 0 && receptorSelection{i,2} <= 3,...
         'SST:InputError','Receptors should either be targeted [1], silenced [2], or Ignored [3]');
 end
 targetReceptors = find([receptorSelection{:,2}] == 1);
 silenceReceptors = find([receptorSelection{:,2}] == 2);
 ignoredReceptors = find([receptorSelection{:,2}] == 3);
+
+fprintf('<strong>Seeking direction that isolates</strong>')
+fprintf(' %ss,',receptors.labels{targetReceptors});
+fprintf('\n<strong>while silencing</strong>')
+fprintf(' %ss,',receptors.labels{silenceReceptors});
+fprintf('...');
 
 %% Maximize contrast vs. desired contrast TODO
 desiredContrast = [];
@@ -175,6 +180,7 @@ desiredContrast = [];
 directionPrimary = ReceptorIsolate(receptors.T.T_energyNormalized,targetReceptors,ignoredReceptors,[],...
     device.B_primary, backgroundPrimary, backgroundPrimary, [],...
     device.primaryHeadRoom, device.maxPowerDiff, desiredContrast, device.ambientSpd);
+fprintf('done.\n');
 
 %% Calculate nominal contrasts
 backgroundReceptor = receptors.T.T_quantalIsomerizations * (device.B_primary * backgroundPrimary + device.ambientSpd);

--- a/ReceptorIsolate/SSTReceptorIsolateDemo.m
+++ b/ReceptorIsolate/SSTReceptorIsolateDemo.m
@@ -54,11 +54,8 @@ receptors = SSTReceptorHuman('verbosity','high',...
 
 %% Plot receptor fundamentals
 f1 = figure(); clf;
-subplot(2,3,1); plot_quantalIsomerizations = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_quantalIsomerizations','saveFig',false);
-subplot(2,3,2); plot_quantalAbsorptions = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_quantalAbsorptions','saveFig',false);
-subplot(2,3,3); plot_quantalAbsorptionsNormalized = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_quantalAbsorptionsNormalized','saveFig',false);
-subplot(2,2,3); plot_energy = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_energy','saveFig',false);
-subplot(2,2,4); plot_energyNormalized = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_energyNormalized','saveFig',false);
+subplot(1,2,1); plot_quantalIsomerizations = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_quantalIsomerizations','saveFig',false);
+subplot(1,2,2); plot_energy = receptors.plotSpectralSensitivities('ax',gca,'whichFormat','T_energy','saveFig',false);
 
 
 %% Define devices

--- a/ReceptorIsolate/SSTReceptorIsolateDemo.m
+++ b/ReceptorIsolate/SSTReceptorIsolateDemo.m
@@ -1,16 +1,20 @@
-% SSTReceptor Receptor Isolate Demo
+% SSTReceptor based demo of ReceptorIsolate
 %
 % Demonstration of the ReceptorIsolate engine for finding modulations that
 % isolate various receptors; the receptor fundamentals in this
 % demonstration are generated using the SSTReceptor class(es).
 %
-% NOTE: the SSTReceptorHuman class does not (currently - 10/30/17) correct
-% for photopigment bleaching, unlike the legacy GetHumanPhotoreceptorSS
-% code that the legacy ReceptorIsolateDemo used.
+% NOTES:
+%  NOTE - JV: the SSTReceptorHuman class does not (currently - 10/30/17) correct
+%  for photopigment bleaching, unlike the legacy GetHumanPhotoreceptorSS
+%  code that the legacy ReceptorIsolateDemo used.
 %
-% NOTE: the SSTReceptorHuman class (currently - 10/30/17) uses fixed
-% standard parameters for vessel oxygenation fraction (.85), and vessel
-% overall thickness (5um).
+%  NOTE - JV: the SSTReceptorHuman class (currently - 10/30/17) uses fixed
+%  standard parameters for vessel oxygenation fraction (.85), and vessel
+%  overall thickness (5um).
+%
+% KNOWN BUGS:
+%  Seems to only work for S = [380 2 201]
 
 %% Setup
 % Clear workspace and command window, close plots
@@ -103,7 +107,7 @@ devices(1).maxPowerDiff = 10^-1.5;
 devices(2).name = 'Spectral';
 devices(2).description = 'Hypothetical ideal spectrum producing device (delta function primaries at each wavelength with unit power)';
 devices(2).cal = struct(); % hypothetical devices don't have a calibration file
-devices(2).S = [400 4 76];
+devices(2).S = [380 2 201];
 devices(2).B_primary = eye(devices(2).S(3));
 devices(2).ambientSpd = zeros(size(devices(2).B_primary,2),1);
 devices(2).primaryHeadRoom = 0;
@@ -117,7 +121,7 @@ devices(2).maxPowerDiff = 10000;
 devices(3).name = 'Monitor';
 devices(3).description = 'Some typical monitor (supplied by PTB)';
 devices(3).cal = LoadCalFile('PTB3TestCal');
-devices(3).S = [400 4 76];
+devices(3).S = [380 2 201];
 devices(3).B_primary = SplineSpd(devices(3).cal.S_device,devices(3).cal.P_device,devices(3).S);
 devices(3).ambientSpd = SplineSpd(devices(3).cal.S_ambient,devices(3).cal.P_ambient,devices(3).S);
 devices(3).primaryHeadRoom = 0.02;

--- a/ReceptorIsolate/SSTReceptorIsolateDemo.m
+++ b/ReceptorIsolate/SSTReceptorIsolateDemo.m
@@ -176,7 +176,14 @@ directionPrimary = ReceptorIsolate(receptors.T.T_energyNormalized,targetReceptor
     device.B_primary, backgroundPrimary, backgroundPrimary, [],...
     device.primaryHeadRoom, device.maxPowerDiff, desiredContrast, device.ambientSpd);
 
-%% Calculate nominal contrasts TODO
+%% Calculate nominal contrasts
+backgroundReceptor = receptors.T.T_quantalIsomerizations * (device.B_primary * backgroundPrimary + device.ambientSpd);
+directionReceptor = receptors.T.T_quantalIsomerizations * (device.B_primary * directionPrimary + device.ambientSpd);
+contrasts = (directionReceptor - backgroundReceptor) ./ backgroundReceptor;
+fprintf('\n<strong>Nominal contrasts:</strong>\n')
+for i = 1:numel(receptors.labels)
+    fprintf('<strong>\t%s:</strong> %.2f%%\n',receptors.labels{i},contrasts(i)*100);
+end
 
 %% Generate some plots
 % Plot modulation spectra

--- a/SST/@SSTReceptor/plotSpectralSensitivities.m
+++ b/SST/@SSTReceptor/plotSpectralSensitivities.m
@@ -142,6 +142,7 @@ end
 title(sublabel);
 legend(h, obj.labels); legend boxoff;
 xlim(xLims); ylim(yLims);
+xlabel('Wavelength');
 ylabel(yLabel);
 pbaspect([1 1 1]); set(gca, 'TickDir', 'out');
 

--- a/SST/@SSTReceptor/plotSpectralSensitivities.m
+++ b/SST/@SSTReceptor/plotSpectralSensitivities.m
@@ -17,8 +17,13 @@ function f1 = plotSpectralSensitivities(obj, varargin)
 %     f1 - Figure handle to the created plot.
 %
 % Optional key/value pairs:
-%     'NewWindow' - Logical determing whether to create a new window or to
-%                   keep on plotting in gcf. Can be true or false.
+%     'ax' - Axes object to plot in, rather than gca. If none is provided,
+%            creates a new figure window and new axes object to plot in.
+%
+%     'NewWindow' - LEGACY, replaced by 'ax'. If passed instead of 'ax',
+%                   functions as expected. Ignored if both are passed.
+%                   Logical determing whether to  create a new window or to
+%                   keep on plotting in gcf. Can be true or false. 
 %                   (Default: true)
 %
 %     'whichFormat' - String determining which field of the receptorObj
@@ -52,6 +57,7 @@ function f1 = plotSpectralSensitivities(obj, varargin)
 % along from a calling routine without an error here, if the key/value
 % pairs recognized by the calling routine are not needed here.
 p = inputParser; p.KeepUnmatched = true;
+p.addParameter('ax',[], @ishandle);
 p.addParameter('NewWindow', true, @islogical);
 p.addParameter('whichFormat', 'T_energyNormalized', @ischar);
 p.addParameter('logUnits', false, @islogical);
@@ -101,9 +107,16 @@ if p.Results.logUnits
 end
 
 %% Make the figure
-if (p.Results.NewWindow)
-    f1 = figure; clf; hold on;
+if isempty(p.Results.ax)
+    if p.Results.NewWindow
+        f1 = figure(); clf; hold on;
+    else
+        f1 = gcf;
+    end
+    ax = gca;
 else
+    ax = p.Results.ax;
+    axes(ax);
     f1 = gcf;
 end
 
@@ -122,7 +135,7 @@ yLims = [min(min(T_receptors))*0.9  max(max(T_receptors))*1.1];
 NReceptorsToPlot = length(obj.labels);
 for ii = 1:NReceptorsToPlot
     % Plot the fundamentals
-    h(ii) = plot(wls, T_receptors(ii, :), '-', 'LineWidth', 2, 'Color', theRGB(ii, :)); hold on;
+    h(ii) = plot(ax,wls, T_receptors(ii, :), '-', 'LineWidth', 2, 'Color', theRGB(ii, :)); hold on;
 end
 
 % Tune the plot properties

--- a/SST/helpers/LEDPrimaries.m
+++ b/SST/helpers/LEDPrimaries.m
@@ -1,0 +1,26 @@
+function B_primary = LEDPrimaries(S, peakWls, FWHM, maxPower)
+%LEDPRIMARIES constructs B_primary for any N LEDs
+%
+%   S = spectral resolution to define primaries, in standard PTB format ([start delta N]) 
+%
+%   peakWls = vector of wavelength (in nm) of peak output for each LED
+%
+%   FWHM = vector of full-width half maximum for each LED
+%
+%   maxPower = vector of power at peak output for each LED
+%
+if (S ~= MakeItS(S))
+    warning('S not in standard PTB format ( [start delta N] )! Casting...');
+end
+
+assert(numel(peakWls) == numel(FWHM) && numel(peakWls) == numel(maxPower),...
+    'Inconsistent number of LEDs specified in input arguments');
+
+wls = SToWls(S);
+
+spd = normpdf(wls,peakWls,FWHM);
+B_primary = spd ./ max(spd) .* maxPower;
+
+
+end
+


### PR DESCRIPTION
Since the SST has moved to using SSTReceptor class and its derivatives, I rewrote the basic parts of the ReceptorIsolateDemo to demonstrate this.

In the process, I ended up making some changes to `plotSpectralSensitivities`. I also created a function to generate the `B_primary` for an N-LED device.

A few things to note/discuss:
1. This new demo lives side by side with the old one (`ReceptorIsolateDemo.m`), rather than replacing it. I figured it's not my place to replace it.
2. Under /SST/ReceptorIsolate/dev, there was already a stub of a `SSTReceptorIsolateDemo.m`. I have not removed this, since I'm not sure whether my demo fulfills all the requirements of this new demo too.
3. My demo makes use of the original ReceptorIsolate.m, NOT the new ReceptorIsolateOptimBackgroundMulti.m.
4. Related to (2), under /SST/ReceptorIsolate/dev, there is also a `ReceptorIsolateOptim.m`, that is close, but not identical to `ReceptorIsolateOptimBackgroundMulti.m`.
5. My demo uses `T_energyNormalized`, just like the old `ReceptorIsolateDemo.m`. The other /dev/SSTReceptorIsolateDemo.m seems to use `T_energy`, with `ReceptorIsolateOptim`. If I use `T_energy` in my demo, it does not always work. Example: I can create an S-cone isolating direction, but not an L-cone isolating one...