### PR TITLE
New SPDToReceptorContrast

### DIFF
--- a/ConeContrastCalcs/SPDToReceptorContrast.m
+++ b/ConeContrastCalcs/SPDToReceptorContrast.m
@@ -28,7 +28,17 @@ function [contrasts, response, responseDiff] = SPDToReceptorContrast(SPDs,SSTRec
 %                   response(R,j) - response(R,i).
 %
 % Optional key/value pairs:
-%   None.
+%    None.
+%
+% Notes:
+%    In the case that only 2 SPDs are passed (e.g., a background SPD and a
+%    direction SPD), the outputs are simplified as follows:
+%       responseDiff - Rx2 matrix, where the first column is the
+%                      response(R,j) - reponse(R,i), and the second column 
+%                      the inverse
+%       contrasts    - Rx2 matrix, where the first column is the contrast
+%                      relative to the first SPD, and the second column is
+%                      the contrast relative to the second SPD.
 
 % History:
 %    12/01/17  jv  created based on ComputeAndReportContrastsFromSpds     
@@ -41,7 +51,17 @@ function [contrasts, response, responseDiff] = SPDToReceptorContrast(SPDs,SSTRec
     temp = reshape(response',[1,size(SPDs,2),size(SSTReceptors.labels,2)]);
     temp = repmat(temp,[size(SPDs,2),1,1]);
     responseDiff = temp - permute(temp,[2 1 3]);
+
+    % Squeeze, if only 2 SPDs were passed
+    if size(SPDs,2) == 2
+        responseDiff = squeeze([responseDiff(1,2,:) responseDiff(2,1,:)])';
+        % denominator for contrast is the repsonses matrix when N = 2
+        temp = response;
+    else
+        % denominator for contrast is a permutation of the temp matrix
+        temp = permute(temp,[2 1 3]);
+    end
     
     % Calculate contrasts
-    contrasts = responseDiff ./ permute(temp,[2 1 3]) * 100;
+    contrasts = responseDiff ./ temp * 100;
 end

--- a/ConeContrastCalcs/SPDToReceptorContrast.m
+++ b/ConeContrastCalcs/SPDToReceptorContrast.m
@@ -39,19 +39,27 @@ function [contrasts, response, responseDiff] = SPDToReceptorContrast(SPDs,SSTRec
 %       contrasts    - Rx2 matrix, where the first column is the contrast
 %                      relative to the first SPD, and the second column is
 %                      the contrast relative to the second SPD.
+%
+%    In the case that only 1 SPD is passed, response is returned as normal,
+%    but responseDiff and contrasts are returned as nWlsx1 columnvectors of
+%    NaNs.
 
 % History:
 %    12/01/17  jv  created based on ComputeAndReportContrastsFromSpds     
 %
-     
-    % Calculate receptor response
-    response = SSTReceptors.T.T_energyNormalized * SPDs;
+    
+% Calculate receptor response
+response = SSTReceptors.T.T_energyNormalized * SPDs;
 
+if size(SPDs,2) <= 1
+    responseDiff = NaN(size(SPDs));
+    contrasts = NaN(size(SPDs));
+else
     % Calculate difference in receptor responses between all SPDs
     temp = reshape(response',[1,size(SPDs,2),size(SSTReceptors.labels,2)]);
     temp = repmat(temp,[size(SPDs,2),1,1]);
     responseDiff = temp - permute(temp,[2 1 3]);
-
+    
     % Squeeze, if only 2 SPDs were passed
     if size(SPDs,2) == 2
         responseDiff = squeeze([responseDiff(1,2,:) responseDiff(2,1,:)])';
@@ -64,4 +72,5 @@ function [contrasts, response, responseDiff] = SPDToReceptorContrast(SPDs,SSTRec
     
     % Calculate contrasts
     contrasts = responseDiff ./ temp * 100;
+end
 end

--- a/ConeContrastCalcs/SPDToReceptorContrast.m
+++ b/ConeContrastCalcs/SPDToReceptorContrast.m
@@ -1,0 +1,43 @@
+function [contrasts, response, responseDiff] = SPDToReceptorContrast(SPDs,SSTReceptors)
+% Calculates the contrast on each receptor between two SPDs
+%  
+% Description:
+%
+% Syntax:
+%   contrasts = SPDtoReceptorContrast(SPDs,SSTReceptors)
+%
+% Inputs:
+%   SPDs            nWlsxN Matrix of spectral power distributions, where
+%                   nWls is the wavelength specification, and N is the
+%                   number of spectra to calculate contrasts across
+%
+%   SSTReceptors    SSTReceptor object that specifies the receptors on
+%                   which to calculate contrasts
+%
+% Optional key/value pairs:
+%
+% Outputs:
+%   contrasts       NxNxR matrix of contrasts (one NxN matrix per receptor 
+%                   type)
+%
+%   response        RxN matrix of responses of each receptor type to each 
+%                   PSD
+%
+%   responseDiff    NxNxR matrix of differences in responses (one NxN 
+%                   matrix per receptor type)
+%
+% Notes:
+%
+% See also:
+     
+    % Calculate receptor response
+    response = SSTReceptors.T.T_energyNormalized * SPDs;
+
+    % Calculate difference in receptor responses between all SPDs
+    temp = reshape(response',[1,size(SPDs,2),size(SSTReceptors.labels,2)]);
+    temp = repmat(temp,[size(SPDs,2),1,1]);
+    responseDiff = temp - permute(temp,[2 1 3]);
+    
+    % Calculate contrasts
+    contrasts = responseDiff ./ permute(temp,[2 1 3]) * 100;
+end

--- a/ConeContrastCalcs/SPDToReceptorContrast.m
+++ b/ConeContrastCalcs/SPDToReceptorContrast.m
@@ -1,34 +1,40 @@
 function [contrasts, response, responseDiff] = SPDToReceptorContrast(SPDs,SSTReceptors)
-% Calculates the contrast on each receptor between two SPDs
-%  
-% Description:
+% Calculates the contrast on photoreceptors between SPDs
 %
 % Syntax:
 %   contrasts = SPDtoReceptorContrast(SPDs,SSTReceptors)
 %
+% Description:
+%    SPDToReceptorContrast takes in spectra, as a set of columnvectors of
+%    power at wavelength for each spectrum, and takes in a set of
+%    receptors, as a SSTReceptor object, and calculates the contrast on
+%    each receptor between all pairs of spectra.
+%
 % Inputs:
-%   SPDs            nWlsxN Matrix of spectral power distributions, where
+%    SPDs         - nWlsxN Matrix of spectral power distributions, where
 %                   nWls is the wavelength specification, and N is the
 %                   number of spectra to calculate contrasts across
-%
-%   SSTReceptors    SSTReceptor object that specifies the receptors on
+%    SSTReceptors - SSTReceptor object that specifies the receptors on
 %                   which to calculate contrasts
 %
-% Optional key/value pairs:
-%
 % Outputs:
-%   contrasts       NxNxR matrix of contrasts (one NxN matrix per receptor 
+%    contrasts    - NxNxR matrix of contrasts (one NxN matrix per receptor 
 %                   type)
-%
-%   response        RxN matrix of responses of each receptor type to each 
+%    response     - RxN matrix of responses of each receptor type to each 
 %                   PSD
-%
-%   responseDiff    NxNxR matrix of differences in responses (one NxN 
+%    responseDiff - NxNxR matrix of differences in responses (one NxN 
 %                   matrix per receptor type)
+%
+% Optional key/value pairs:
+%   None.
 %
 % Notes:
 %
 % See also:
+
+% History:
+%    12/01/17  jv  created. based on ComputerAndReportContrastsFromSpds     
+%
      
     % Calculate receptor response
     response = SSTReceptors.T.T_energyNormalized * SPDs;

--- a/ConeContrastCalcs/SPDToReceptorContrast.m
+++ b/ConeContrastCalcs/SPDToReceptorContrast.m
@@ -18,22 +18,20 @@ function [contrasts, response, responseDiff] = SPDToReceptorContrast(SPDs,SSTRec
 %                   which to calculate contrasts
 %
 % Outputs:
-%    contrasts    - NxNxR matrix of contrasts (one NxN matrix per receptor 
-%                   type)
+%    contrasts    - NxNxR matrix of contrasts in % (one NxN
+%                   matrix per receptor type), where contrasts(i,j,R) =
+%                   responseDiff(i,j,R) / response(R,i) * 100%
 %    response     - RxN matrix of responses of each receptor type to each 
-%                   PSD
+%                   SPD
 %    responseDiff - NxNxR matrix of differences in responses (one NxN 
-%                   matrix per receptor type)
+%                   matrix per receptor type), where responseDiff(i,j,R) =
+%                   response(R,j) - response(R,i).
 %
 % Optional key/value pairs:
 %   None.
-%
-% Notes:
-%
-% See also:
 
 % History:
-%    12/01/17  jv  created. based on ComputerAndReportContrastsFromSpds     
+%    12/01/17  jv  created based on ComputeAndReportContrastsFromSpds     
 %
      
     % Calculate receptor response


### PR DESCRIPTION
This new function `SPDToReceptorContrast` uses the SSTReceptor objects, while the old function `ComputeAndReportContrastFromSPDs` uses the output of `GetHumanPhotoreceptorSS` to define receptors). The new function does not remove the old function, they can live side by side.

Moreover, this version can handle any N spectra, and will calculate all contrasts between those. This makes the output a little wonkier, but does allow you to compare several different directions, and the nominal and measured SPDs at the same time.