### PR TITLE
Bugfix: fractionConeBleachedFromIsom must be triplet

### DIFF
--- a/PhotoreceptorSensitivity/GetHumanPhotoreceptorSS.m
+++ b/PhotoreceptorSensitivity/GetHumanPhotoreceptorSS.m
@@ -237,6 +237,7 @@ LConeFractionSet = false;
 MConeFractionSet = false;
 SConeFractionSet = false;
 if length(photoreceptorClasses) > 1
+    fractionConeBleachedFromIsom = [0 0 0]; % initialize as triplet for PTB
     for i = 1:length(photoreceptorClasses)
         switch photoreceptorClasses{i}
             case {'LConeTabulatedAbsorbance' 'LConeTabulatedAbsorbancePenumbral' 'LConeSSNomogramLegacy'}


### PR DESCRIPTION
`GetHumanPhotoreceptorSS` is not well setup to do uncommon numbers of receptors, e.g., 2 as for tritanopia. In particular, the bleached fraction must be passed to PTB as a triplet, but that's not enforced/guaranteed. By initializing `fractionConeBleachedFromIsom` as a triplet, this seems to be fixed.